### PR TITLE
新增错误检测专用模型

### DIFF
--- a/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
+++ b/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
@@ -2,7 +2,7 @@
 轻量字级「是否可能出错」推理头（ELECTRA TokenClassification），与主仓库
 `ErrorCorrect.hf_infer / vllm_infer` 的输入形式一致：list[str] 原句。
 
-输出为结构化 dict，字段与 docskill 字级流水线 `pipeline_char.py` 的 JSON 行一致，
+输出为结构化 dict，字段 字级流水线 `pipeline_char.py` 的 JSON 行一致，
 便于在大模型纠错前做门控，减少无效调用。
 
 使用方式（放在本仓库 ChineseErrorCorrector 包内后）::
@@ -32,7 +32,7 @@ from ChineseErrorCorrector.config import DEVICE
 
 
 def _normalize_text(text: str) -> str:
-    """与 docskill `normalize.normalize_text` 一致：NFKC + 空白折叠。"""
+    """与  `normalize.normalize_text` 一致：NFKC + 空白折叠。"""
     if text is None:
         return ""
     s = unicodedata.normalize("NFKC", str(text))

--- a/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
+++ b/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
@@ -2,15 +2,21 @@
 轻量字级「是否可能出错」推理头（ELECTRA TokenClassification），与主仓库
 `ErrorCorrect.hf_infer / vllm_infer` 的输入形式一致：list[str] 原句。
 
-输出为结构化 dict，字段 字级流水线 `pipeline_char.py` 的 JSON 行一致，
-便于在大模型纠错前做门控，减少无效调用。
+输出为结构化 dict（`source`、`text`、`need_correct`、`max_p_err`、`char_flags`、`char_end`），
+便于在大模型纠错前做门控。
+
+公开权重默认与模块常量 `CHAR_GATE_HF_REPO_ID` / `CHAR_GATE_MODEL_CARD_URL` 一致；也可用环境变量
+`CHAR_GATE_HF_REPO_ID` 覆盖默认 id，无需改代码。
 
 使用方式（放在本仓库 ChineseErrorCorrector 包内后）::
 
-    from ChineseErrorCorrector.llm.infer.electra_char_gate_infer import ElectraCharGateInfer
+    from ChineseErrorCorrector.llm.infer.electra_char_gate_infer import (
+        ElectraCharGateInfer,
+        CHAR_GATE_HF_REPO_ID,
+    )
 
     gate = ElectraCharGateInfer(
-        model_name_or_path="你的HF用户名/chinese-char-error-detector-electra",
+        model_name_or_path=CHAR_GATE_HF_REPO_ID,
         sentence_threshold=0.5,
     )
     rows = gate.infer(["对待每一项工作都要一丝不够。", "大约半个小时左右"])
@@ -19,6 +25,7 @@
 """
 from __future__ import annotations
 
+import os
 import re
 import unicodedata
 from typing import Any
@@ -30,9 +37,17 @@ from transformers import AutoModelForTokenClassification, AutoTokenizer
 
 from ChineseErrorCorrector.config import DEVICE
 
+# 与 Hugging Face 模型卡 URL 一致：`https://huggingface.co/{CHAR_GATE_HF_REPO_ID}`
+# 发布到 Hub 后请改为实际上传的 ``用户名或组织名/仓库名``（与本文件同目录说明 md 同步修改）。
+CHAR_GATE_HF_REPO_ID = os.environ.get(
+    "CHAR_GATE_HF_REPO_ID",
+    "username/chinese-char-error-detector-electra",
+)
+CHAR_GATE_MODEL_CARD_URL = f"https://huggingface.co/{CHAR_GATE_HF_REPO_ID}"
+
 
 def _normalize_text(text: str) -> str:
-    """与  `normalize.normalize_text` 一致：NFKC + 空白折叠。"""
+    """与 docskill `normalize.normalize_text` 一致：NFKC + 空白折叠。"""
     if text is None:
         return ""
     s = unicodedata.normalize("NFKC", str(text))

--- a/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
+++ b/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
@@ -1,0 +1,223 @@
+"""
+轻量字级「是否可能出错」推理头（ELECTRA TokenClassification），与主仓库
+`ErrorCorrect.hf_infer / vllm_infer` 的输入形式一致：list[str] 原句。
+
+输出为结构化 dict，字段与 docskill 字级流水线 `pipeline_char.py` 的 JSON 行一致，
+便于在大模型纠错前做门控，减少无效调用。
+
+使用方式（放在本仓库 ChineseErrorCorrector 包内后）::
+
+    from ChineseErrorCorrector.llm.infer.electra_char_gate_infer import ElectraCharGateInfer
+
+    gate = ElectraCharGateInfer(
+        model_name_or_path="你的HF用户名/chinese-char-error-detector-electra",
+        sentence_threshold=0.5,
+    )
+    rows = gate.infer(["对待每一项工作都要一丝不够。", "大约半个小时左右"])
+
+依赖：torch, transformers；需 Fast tokenizer（与训练时一致）。
+"""
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from transformers import AutoModelForTokenClassification, AutoTokenizer
+
+from ChineseErrorCorrector.config import DEVICE
+
+
+def _normalize_text(text: str) -> str:
+    """与 docskill `normalize.normalize_text` 一致：NFKC + 空白折叠。"""
+    if text is None:
+        return ""
+    s = unicodedata.normalize("NFKC", str(text))
+    s = s.strip()
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+
+def _offsets_batch_to_lists(offset: Any) -> list[list[tuple[int, int]]]:
+    if isinstance(offset, torch.Tensor):
+        arr = offset.cpu().numpy()
+        if arr.ndim == 2:
+            return [[tuple(map(int, row)) for row in arr]]
+        return [[tuple(map(int, row)) for row in seq] for seq in arr]
+    if isinstance(offset, list):
+        out: list[list[tuple[int, int]]] = []
+        for row in offset:
+            if isinstance(row, torch.Tensor):
+                r = row.cpu().numpy()
+                out.append([tuple(map(int, x)) for x in r])
+            else:
+                out.append([(int(t[0]), int(t[1])) for t in row])
+        return out
+    raise TypeError(f"不支持的 offset_mapping 类型: {type(offset)}")
+
+
+def _decode_char_level_for_one(
+    text: str,
+    off_list: list[tuple[int, int]],
+    logits: np.ndarray,
+) -> tuple[int, np.ndarray, np.ndarray, np.ndarray]:
+    probs = F.softmax(torch.from_numpy(logits), dim=-1).numpy()
+    p_err = probs[:, 1]
+    pred_tok = logits.argmax(axis=-1)
+
+    char_end = 0
+    for s, e in off_list:
+        if s == 0 and e == 0:
+            continue
+        char_end = max(char_end, e)
+
+    char_end = min(char_end, len(text))
+    char_pred = np.zeros(char_end, dtype=np.int64)
+    char_max_p = np.zeros(char_end, dtype=np.float32)
+
+    for j, (st, en) in enumerate(off_list):
+        if st == 0 and en == 0:
+            continue
+        st = min(int(st), char_end)
+        en = min(int(en), char_end)
+        if st >= en:
+            continue
+        if pred_tok[j] == 1:
+            char_pred[st:en] = 1
+        char_max_p[st:en] = np.maximum(char_max_p[st:en], float(p_err[j]))
+
+    return char_end, char_pred, char_max_p, pred_tok
+
+
+@torch.inference_mode()
+def _forward_char_preds_batch(
+    texts: list[str],
+    model: Any,
+    tokenizer: Any,
+    device: torch.device,
+    max_length: int,
+) -> list[tuple[int, np.ndarray, np.ndarray, np.ndarray]]:
+    if not texts:
+        return []
+    enc = tokenizer(
+        list(texts),
+        max_length=max_length,
+        truncation=True,
+        padding=True,
+        return_offsets_mapping=True,
+        return_tensors="pt",
+    )
+    offset = enc.pop("offset_mapping")
+    off_lists = _offsets_batch_to_lists(offset)
+    enc = {k: v.to(device) for k, v in enc.items()}
+    logits = model(**enc).logits.float().cpu().numpy()
+    out: list[tuple[int, np.ndarray, np.ndarray, np.ndarray]] = []
+    for i, text in enumerate(texts):
+        out.append(_decode_char_level_for_one(text, off_lists[i], logits[i]))
+    return out
+
+
+class ElectraCharGateInfer:
+    """
+    字级检错门控：输入与 `ErrorCorrect` 相同的句子列表；输出每条句子的
+    need_correct / 字级 0-1 串 / 最大错字概率等。
+    """
+
+    def __init__(
+        self,
+        model_name_or_path: str,
+        *,
+        device: str | torch.device | None = None,
+        max_length: int = 256,
+        sentence_threshold: float = 0.5,
+        batch_size: int = 32,
+    ) -> None:
+        self.sentence_threshold = float(sentence_threshold)
+        self.max_length = int(max_length)
+        self.batch_size = max(1, int(batch_size))
+        dev = device if device is not None else DEVICE
+        self._device = torch.device(dev)
+
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True)
+        if not getattr(self.tokenizer, "is_fast", False):
+            raise RuntimeError("字级门控需要 Fast tokenizer（return_offsets_mapping）")
+        self.model = AutoModelForTokenClassification.from_pretrained(model_name_or_path)
+        self.model.eval().to(self._device)
+
+    def infer(self, input_list: list[str]) -> list[dict[str, Any]]:
+        """
+        :param input_list: 与 `ErrorCorrect` 示例中相同的原句列表。
+        :return: 与 `pipeline_char` 每行 JSON 对齐的 dict 列表；并额外带 `source` 键指向入参原句。
+        """
+        out_rows: list[dict[str, Any]] = []
+        buf_texts: list[str] = []
+        buf_sources: list[str] = []
+
+        def flush() -> None:
+            nonlocal buf_texts, buf_sources
+            if not buf_texts:
+                return
+            preds = _forward_char_preds_batch(
+                buf_texts, self.model, self.tokenizer, self._device, self.max_length
+            )
+            for src, text, (char_end, char_pred, char_max_p, _) in zip(
+                buf_sources, buf_texts, preds
+            ):
+                max_p = float(char_max_p.max()) if len(char_max_p) else 0.0
+                need = max_p >= self.sentence_threshold
+                out_rows.append(
+                    {
+                        "source": src,
+                        "text": text,
+                        "need_correct": need,
+                        "max_p_err": max_p,
+                        "char_flags": "".join(str(int(x)) for x in char_pred.tolist()),
+                        "char_end": int(char_end),
+                    }
+                )
+            buf_texts = []
+            buf_sources = []
+
+        for raw in input_list:
+            text = _normalize_text(raw)
+            if not text:
+                out_rows.append(
+                    {
+                        "source": raw,
+                        "text": "",
+                        "need_correct": False,
+                        "max_p_err": 0.0,
+                        "char_flags": "",
+                        "char_end": 0,
+                    }
+                )
+                continue
+            buf_sources.append(raw)
+            buf_texts.append(text)
+            if len(buf_texts) >= self.batch_size:
+                flush()
+        flush()
+        return out_rows
+
+
+def filter_sources_for_llm(
+    gate_rows: list[dict[str, Any]],
+) -> tuple[list[str], list[int]]:
+    """
+    根据 gate 结果筛出建议送大模型纠错的句子；返回 (子列表, 在原 input_list 中的下标)。
+    仅对 need_correct 为 True 的项保留 source（原句字符串）。
+    """
+    sub: list[str] = []
+    idxs: list[int] = []
+    for i, row in enumerate(gate_rows):
+        if row.get("need_correct"):
+            sub.append(row["source"])
+            idxs.append(i)
+    return sub, idxs
+
+
+if __name__ == "__main__":
+    pass

--- a/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
+++ b/ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py
@@ -35,15 +35,36 @@ import torch
 import torch.nn.functional as F
 from transformers import AutoModelForTokenClassification, AutoTokenizer
 
-from ChineseErrorCorrector.config import DEVICE
+from ChineseErrorCorrector.config import DEVICE, TextCorrectConfig
 
-# 与 Hugging Face 模型卡 URL 一致：`https://huggingface.co/{CHAR_GATE_HF_REPO_ID}`
-# 发布到 Hub 后请改为实际上传的 ``用户名或组织名/仓库名``（与本文件同目录说明 md 同步修改）。
+# 与 Hugging Face 模型卡 URL 一致：`https://huggingface.co/{CHAR_GATE_HF_REPO_ID}`。
+# 若 config.py 中提供 TextCorrectConfig.DEFAULT_DETECTOR_PATH，本文件会优先使用配置值。
 CHAR_GATE_HF_REPO_ID = os.environ.get(
     "CHAR_GATE_HF_REPO_ID",
     "username/chinese-char-error-detector-electra",
 )
 CHAR_GATE_MODEL_CARD_URL = f"https://huggingface.co/{CHAR_GATE_HF_REPO_ID}"
+
+
+def is_detector_enabled() -> bool:
+    """是否启用 detector（用于主流程判断）。默认 True 以兼容旧配置。"""
+    return bool(getattr(TextCorrectConfig, "USE_DETECTOR", True))
+
+
+def get_default_detector_path() -> str:
+    """
+    detector 模型路径解析优先级：
+      1) 环境变量 CHAR_GATE_HF_REPO_ID
+      2) TextCorrectConfig.DEFAULT_DETECTOR_PATH
+      3) CHAR_GATE_HF_REPO_ID（模块默认）
+    """
+    env_repo = os.environ.get("CHAR_GATE_HF_REPO_ID")
+    if env_repo:
+        return env_repo
+    cfg_path = getattr(TextCorrectConfig, "DEFAULT_DETECTOR_PATH", None)
+    if isinstance(cfg_path, str) and cfg_path.strip():
+        return cfg_path.strip()
+    return CHAR_GATE_HF_REPO_ID
 
 
 def _normalize_text(text: str) -> str:
@@ -143,7 +164,7 @@ class ElectraCharGateInfer:
 
     def __init__(
         self,
-        model_name_or_path: str,
+        model_name_or_path: str | None = None,
         *,
         device: str | torch.device | None = None,
         max_length: int = 256,
@@ -156,10 +177,17 @@ class ElectraCharGateInfer:
         dev = device if device is not None else DEVICE
         self._device = torch.device(dev)
 
-        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, use_fast=True)
+        resolved_model = model_name_or_path or get_default_detector_path()
+        if not resolved_model:
+            raise RuntimeError(
+                "未提供 detector 模型路径。请在 TextCorrectConfig.DEFAULT_DETECTOR_PATH 配置，"
+                "或在初始化 ElectraCharGateInfer 时传 model_name_or_path。"
+            )
+
+        self.tokenizer = AutoTokenizer.from_pretrained(resolved_model, use_fast=True)
         if not getattr(self.tokenizer, "is_fast", False):
             raise RuntimeError("字级门控需要 Fast tokenizer（return_offsets_mapping）")
-        self.model = AutoModelForTokenClassification.from_pretrained(model_name_or_path)
+        self.model = AutoModelForTokenClassification.from_pretrained(resolved_model)
         self.model.eval().to(self._device)
 
     def infer(self, input_list: list[str]) -> list[dict[str, Any]]:

--- a/README.md
+++ b/README.md
@@ -359,6 +359,9 @@ print(response)
 
 **字级门控默认权重（与代码中 `CHAR_GATE_HF_REPO_ID` 一致，发布前请改为你的实际上传路径）**：[模型卡](https://huggingface.co/username/chinese-char-error-detector-electra) · 仓库 id `username/chinese-char-error-detector-electra`。也可设置环境变量 `CHAR_GATE_HF_REPO_ID` 覆盖默认 id；本地 `save_pretrained` 目录可直接传给 `ElectraCharGateInfer(model_name_or_path=...)`。
 
+**数据与复现材料（Hugging Face）**
+字级对齐后的训练/验证数据、生成方式说明，以及本地一键脚本对应的用法与字段说明，均已整理并发布在 Hugging Face Hub 仓库 xurong123/ChineseErrorDetectorElectra：内含可复用的数据说明、样例与相关脚本入口，便于直接 datasets 加载或对照本仓库代码复现预处理流程。详见：https://huggingface.co/xurong123/ChineseErrorDetectorElectra。
+
 ### 加速思路
 
 门控侧参数量远小于 4B/7B 纠错模型，且实现支持 padding batch（`batch_size` 可调）。仅对 `need_correct == True` 的句子跑 hf_infer 或 vllm_infer，无错或风险低的句子不再走自回归生成；实际收益取决于数据中无需纠错的比例、门控阈值和大模型 batch 策略，主要来自减少生成次数。

--- a/README.md
+++ b/README.md
@@ -350,11 +350,14 @@ response = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
 print(response)
 
 ```
+
 ## ELECTRA 字级门控（可选）
 
 中文纠错主链路里，大模型单次推理成本高、延迟大。可选模块 `ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py` 提供一层轻量字级二分类：在 Chinese ELECTRA 判别器上做 TokenClassification 微调，子词对齐到字，给出「该字是否像有错」的标签与概率。在调用 ErrorCorrect 之前，可先判断句子是否值得送进大模型；明显干净的句子可跳过生成，以省算力、降延迟。
 
 权重使用独立的 Hugging Face 模型或本地目录（与主仓库默认纠错权重无关）。需要 Fast tokenizer（`use_fast=True`，支持 offset_mapping）。基座与社区常用骨干一致：[hfl/chinese-electra-180g-base-discriminator](https://huggingface.co/hfl/chinese-electra-180g-base-discriminator)。
+
+**字级门控默认权重（与代码中 `CHAR_GATE_HF_REPO_ID` 一致，发布前请改为你的实际上传路径）**：[模型卡](https://huggingface.co/username/chinese-char-error-detector-electra) · 仓库 id `username/chinese-char-error-detector-electra`。也可设置环境变量 `CHAR_GATE_HF_REPO_ID` 覆盖默认 id；本地 `save_pretrained` 目录可直接传给 `ElectraCharGateInfer(model_name_or_path=...)`。
 
 ### 加速思路
 
@@ -373,13 +376,12 @@ print(response)
 ```python
 from ChineseErrorCorrector.main import ErrorCorrect
 from ChineseErrorCorrector.llm.infer.electra_char_gate_infer import (
+    CHAR_GATE_HF_REPO_ID,
     ElectraCharGateInfer,
     filter_sources_for_llm,
 )
 
-GATE_MODEL = "组织或用户名/你的-electra-字级门控模型"
-
-gate = ElectraCharGateInfer(model_name_or_path=GATE_MODEL, sentence_threshold=0.5)
+gate = ElectraCharGateInfer(model_name_or_path=CHAR_GATE_HF_REPO_ID, sentence_threshold=0.5)
 correct = ErrorCorrect()
 
 raw = ["对待每一项工作都要一丝不够。", "大约半个小时左右"]

--- a/README.md
+++ b/README.md
@@ -350,41 +350,25 @@ response = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
 print(response)
 
 ```
-# ELECTRA 错字门控（可选推理头）
+## ELECTRA 字级门控（可选）
 
-## 做什么用
+中文纠错主链路里，大模型单次推理成本高、延迟大。可选模块 `ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py` 提供一层轻量字级二分类：在 Chinese ELECTRA 判别器上做 TokenClassification 微调，子词对齐到字，给出「该字是否像有错」的标签与概率。在调用 ErrorCorrect 之前，可先判断句子是否值得送进大模型；明显干净的句子可跳过生成，以省算力、降延迟。
 
-中文纠错主链路里，**大模型（如 ChineseErrorCorrector3-4B）** 单次推理成本高、延迟大。本模块在 **`ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py`** 中提供一层 **轻量字级二分类**：基于 **Chinese ELECTRA 判别器** 微调的 **TokenClassification**（逐子词对齐到字，输出「该字是否像有错」的 0/1 及错字概率）。
+权重使用独立的 Hugging Face 模型或本地目录（与主仓库默认纠错权重无关）。需要 Fast tokenizer（`use_fast=True`，支持 offset_mapping）。基座与社区常用骨干一致：[hfl/chinese-electra-180g-base-discriminator](https://huggingface.co/hfl/chinese-electra-180g-base-discriminator)。
 
-- **用途**：在调用 `ErrorCorrect` 之前，先判断句子是否 **值得送进大模型**；对明显「干净」的句子可跳过生成，从而 **省算力、降延迟**。
-- **输出**：每条输入对应一个字典，含归一化文本 `text`、是否建议纠错 `need_correct`、句内最大错字概率 `max_p_err`、与字对齐的 `char_flags`（0/1 串）及有效长度 `char_end`，便于按业务阈值做门控或与下游日志对齐。
+### 加速思路
 
-权重为 **独立 Hub 模型或本地目录**（与主仓库默认纠错权重无关）；需 **Fast tokenizer**（`use_fast=True`，支持 `offset_mapping`）。基座谱系与社区常用骨干一致：**[hfl/chinese-electra-180g-base-discriminator](https://huggingface.co/hfl/chinese-electra-180g-base-discriminator)**。
+门控侧参数量远小于 4B/7B 纠错模型，且实现支持 padding batch（`batch_size` 可调）。仅对 `need_correct == True` 的句子跑 hf_infer 或 vllm_infer，无错或风险低的句子不再走自回归生成；实际收益取决于数据中无需纠错的比例、门控阈值和大模型 batch 策略，主要来自减少生成次数。
 
-## 能带来什么加速
+### 性能量级（供参考）
 
-1. **减少大模型调用次数**：仅对 `need_correct == True` 的句子跑 `hf_infer` / `vllm_infer`，无错或模型认为风险低的句子不再走自回归生成。
-2. **门控本身很轻**：ELECTRA 级判别器参数量远小于 4B/7B 纠错模型；实现支持 **padding batch**（`batch_size` 可调），适合线上批量预处理。
-3. **与主仓库输入一致**：`infer(input_list)` 的 `input_list` 与 `ErrorCorrect` 使用的 **原句列表** 相同，便于在现有脚本外包一层，而 **不必改 `main.py`**。
+同类字级门控在公开拼写向语料上，可出现字级召回约 0.99、F1 约 0.75 量级，适合少漏检前筛；精确率相对适中，需用 `sentence_threshold`（句级 max_p_err）在漏检与多调大模型之间折中。语法与混合难例上不如拼写稳，更适合省算力而非单独替代大模型。在 A100、较大 batch（如 512～1024）、`max_length=256` 等设置下，纯 GPU 前向可达约 100+ 句/秒量级；具体以本模型验证与线上实测为准。
 
-实际加速比取决于 **数据中「无需纠错」比例**、门控阈值以及大模型 batch 策略；门控开销通常相对生成可忽略，主要收益来自 **跳过的生成次数**。
+### 输入输出（与主仓库对齐）
 
-## 性能与效果（量级说明）
+与 ErrorCorrect 相同：入参为原句列表 `input_list: list[str]`。出参为字典列表，每条含 `source`、`text`（归一化后用于推理）、`need_correct`、`max_p_err`、`char_flags`、`char_end`。主链路纠错结果仍为 `res_format` 的 `source` / `target` / `errors`。
 
-以下为 **同类字级门控模型** 在公开拼写向语料上曾达到的大致水平，**仅供选型参考**；具体数字随训练数据、checkpoint、阈值而变，以你发布的模型卡与验证集为准。
-
-- **拼写类子集（CSC 风格）**：字级 **召回约 0.99、F1 约 0.75** 量级时，较适合作为「少漏检」的前筛；**精确率**相对适中，可能带来一定误报，需用 **`sentence_threshold`**（句级 `max_p_err` 门限）在「漏检 vs 多调大模型」之间折中。
-- **语法/混合难例**：字级门控对语法错误不如拼写稳，单独做门控时 **误报或漏检** 都可能更明显，更适合 **节省算力** 而非单独替代大模型纠错。
-- **推理吞吐**：在 **A100、batch 较大（如 512～1024）、`max_length=256`** 等设置下，纯 GPU 前向曾测得约 **100+ 句/秒** 量级；CPU 或小 batch 会慢很多。上线请以 **warmup + 实测 QPS** 为准。
-
-## 与主仓库接口的对应关系
-
-| 项目 | 主仓库 `ErrorCorrect` | 字级门控 `ElectraCharGateInfer` |
-|------|------------------------|----------------------------------|
-| 输入 | `input_list: list[str]` | 相同 |
-| 输出 | `res_format` → `source` / `target` / `errors` | `list[dict]`：`source`、`text`、`need_correct`、`max_p_err`、`char_flags`、`char_end` |
-
-## 集成示例（可选，不修改 `main.py`）
+### 示例（可不修改 main.py）
 
 ```python
 from ChineseErrorCorrector.main import ErrorCorrect
@@ -393,7 +377,7 @@ from ChineseErrorCorrector.llm.infer.electra_char_gate_infer import (
     filter_sources_for_llm,
 )
 
-GATE_MODEL = "组织或用户名/你的-electra-字级门控模型"  # Hub id 或本地路径
+GATE_MODEL = "组织或用户名/你的-electra-字级门控模型"
 
 gate = ElectraCharGateInfer(model_name_or_path=GATE_MODEL, sentence_threshold=0.5)
 correct = ErrorCorrect()
@@ -402,7 +386,6 @@ raw = ["对待每一项工作都要一丝不够。", "大约半个小时左右"]
 gate_rows = gate.infer(raw)
 to_fix, _ = filter_sources_for_llm(gate_rows)
 llm_out = correct.hf_infer(to_fix) if to_fix else []
-# 需保持与原列表顺序一致时，请按索引把门控结果与大模型输出合并（略）
 ```
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -363,9 +363,31 @@ print(response)
 
 门控侧参数量远小于 4B/7B 纠错模型，且实现支持 padding batch（`batch_size` 可调）。仅对 `need_correct == True` 的句子跑 hf_infer 或 vllm_infer，无错或风险低的句子不再走自回归生成；实际收益取决于数据中无需纠错的比例、门控阈值和大模型 batch 策略，主要来自减少生成次数。
 
+### 数据与标签
+
+- **训练/验证主 JSONL**：由 CEC 转换而来，每行 `{"source","target"}`；本地常见文件名 `data/cec_train.jsonl`、`data/cec_validation.jsonl`。
+- **字级标签**：`char_align.py` 对归一化后的 `source`/`target` 做 `difflib.SequenceMatcher`，`replace`/`delete` 在 source 上标 **1**，其余 **0**；纯 insert 在 target 侧时 source 可能全 0，属规则定义而非实现错误。
+- **分层验证集** `data/val_task_stratified.jsonl`：由 `prepare_task_validation_jsonl.py` 从 **csc / cgc** 等抽样，字段含 `task`（`spelling` / `grammar` / `mixed`）与 `corpus`。**mixed** 在 Lang8 不可用时自动回退为 **`cec_validation.jsonl`** 抽样，并在 `corpus` 中标注 `mixed_fallback:cec_validation.jsonl`。
+
+---
+
 ### 性能量级（供参考）
 
-同类字级门控在公开拼写向语料上，可出现字级召回约 0.99、F1 约 0.75 量级，适合少漏检前筛；精确率相对适中，需用 `sentence_threshold`（句级 max_p_err）在漏检与多调大模型之间折中。语法与混合难例上不如拼写稳，更适合省算力而非单独替代大模型。在 A100、较大 batch（如 512～1024）、`max_length=256` 等设置下，纯 GPU 前向可达约 100+ 句/秒量级；具体以本模型验证与线上实测为准。
+## Evaluation (Quick Snapshot)
+
+`val_task_stratified.jsonl`（7500 句，spelling/grammar/mixed 各 2500）上的一次对照实验：
+
+| Split | ELECTRA (P / R / F1) | MacBERT (P / R / F1) | Better |
+|---|---|---|---|
+| Overall (char-level) | 0.256 / 0.822 / 0.391 | 0.264 / 0.797 / 0.396 | MacBERT F1 略高，ELECTRA Recall 更高 |
+| Spelling (char-level) | **0.611 / 0.986 / 0.754** | 0.568 / 0.984 / 0.720 | **ELECTRA** |
+| Grammar (char-level) | 0.214 / 0.823 / 0.339 | **0.225 / 0.838 / 0.355** | **MacBERT** |
+| Mixed (char-level) | 0.206 / **0.732** / **0.322** | **0.210** / 0.662 / 0.319 | ELECTRA（Recall/F1） |
+| Sentence gate (best F1, `max_p_err` sweep) | **0.859** | 0.854 | **ELECTRA** |
+
+
+> 注：这是阶段性结果（固定一次实验配置）。上线时请在你的验证集上重新做阈值 sweep。
+同类字级门控在公开拼写向语料上，可出现字级召回约 0.986、F1 约 0.75 量级，适合少漏检前筛；精确率相对适中，需用 `sentence_threshold`（句级 max_p_err）在漏检与多调大模型之间折中。语法与混合难例上不如拼写稳，更适合省算力而非单独替代大模型。在 A100、较大 batch（如 512～1024）、`max_length=256` 等设置下，纯 GPU 前向可达约 100+ 句/秒量级；具体以本模型验证与线上实测为准。
 
 ### 输入输出（与主仓库对齐）
 

--- a/README.md
+++ b/README.md
@@ -350,7 +350,60 @@ response = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)[0]
 print(response)
 
 ```
+# ELECTRA 错字门控（可选推理头）
 
+## 做什么用
+
+中文纠错主链路里，**大模型（如 ChineseErrorCorrector3-4B）** 单次推理成本高、延迟大。本模块在 **`ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py`** 中提供一层 **轻量字级二分类**：基于 **Chinese ELECTRA 判别器** 微调的 **TokenClassification**（逐子词对齐到字，输出「该字是否像有错」的 0/1 及错字概率）。
+
+- **用途**：在调用 `ErrorCorrect` 之前，先判断句子是否 **值得送进大模型**；对明显「干净」的句子可跳过生成，从而 **省算力、降延迟**。
+- **输出**：每条输入对应一个字典，含归一化文本 `text`、是否建议纠错 `need_correct`、句内最大错字概率 `max_p_err`、与字对齐的 `char_flags`（0/1 串）及有效长度 `char_end`，便于按业务阈值做门控或与下游日志对齐。
+
+权重为 **独立 Hub 模型或本地目录**（与主仓库默认纠错权重无关）；需 **Fast tokenizer**（`use_fast=True`，支持 `offset_mapping`）。基座谱系与社区常用骨干一致：**[hfl/chinese-electra-180g-base-discriminator](https://huggingface.co/hfl/chinese-electra-180g-base-discriminator)**。
+
+## 能带来什么加速
+
+1. **减少大模型调用次数**：仅对 `need_correct == True` 的句子跑 `hf_infer` / `vllm_infer`，无错或模型认为风险低的句子不再走自回归生成。
+2. **门控本身很轻**：ELECTRA 级判别器参数量远小于 4B/7B 纠错模型；实现支持 **padding batch**（`batch_size` 可调），适合线上批量预处理。
+3. **与主仓库输入一致**：`infer(input_list)` 的 `input_list` 与 `ErrorCorrect` 使用的 **原句列表** 相同，便于在现有脚本外包一层，而 **不必改 `main.py`**。
+
+实际加速比取决于 **数据中「无需纠错」比例**、门控阈值以及大模型 batch 策略；门控开销通常相对生成可忽略，主要收益来自 **跳过的生成次数**。
+
+## 性能与效果（量级说明）
+
+以下为 **同类字级门控模型** 在公开拼写向语料上曾达到的大致水平，**仅供选型参考**；具体数字随训练数据、checkpoint、阈值而变，以你发布的模型卡与验证集为准。
+
+- **拼写类子集（CSC 风格）**：字级 **召回约 0.99、F1 约 0.75** 量级时，较适合作为「少漏检」的前筛；**精确率**相对适中，可能带来一定误报，需用 **`sentence_threshold`**（句级 `max_p_err` 门限）在「漏检 vs 多调大模型」之间折中。
+- **语法/混合难例**：字级门控对语法错误不如拼写稳，单独做门控时 **误报或漏检** 都可能更明显，更适合 **节省算力** 而非单独替代大模型纠错。
+- **推理吞吐**：在 **A100、batch 较大（如 512～1024）、`max_length=256`** 等设置下，纯 GPU 前向曾测得约 **100+ 句/秒** 量级；CPU 或小 batch 会慢很多。上线请以 **warmup + 实测 QPS** 为准。
+
+## 与主仓库接口的对应关系
+
+| 项目 | 主仓库 `ErrorCorrect` | 字级门控 `ElectraCharGateInfer` |
+|------|------------------------|----------------------------------|
+| 输入 | `input_list: list[str]` | 相同 |
+| 输出 | `res_format` → `source` / `target` / `errors` | `list[dict]`：`source`、`text`、`need_correct`、`max_p_err`、`char_flags`、`char_end` |
+
+## 集成示例（可选，不修改 `main.py`）
+
+```python
+from ChineseErrorCorrector.main import ErrorCorrect
+from ChineseErrorCorrector.llm.infer.electra_char_gate_infer import (
+    ElectraCharGateInfer,
+    filter_sources_for_llm,
+)
+
+GATE_MODEL = "组织或用户名/你的-electra-字级门控模型"  # Hub id 或本地路径
+
+gate = ElectraCharGateInfer(model_name_or_path=GATE_MODEL, sentence_threshold=0.5)
+correct = ErrorCorrect()
+
+raw = ["对待每一项工作都要一丝不够。", "大约半个小时左右"]
+gate_rows = gate.infer(raw)
+to_fix, _ = filter_sources_for_llm(gate_rows)
+llm_out = correct.hf_infer(to_fix) if to_fix else []
+# 需保持与原列表顺序一致时，请按索引把门控结果与大模型输出合并（略）
+```
 
 ## Citation
 


### PR DESCRIPTION
本 PR 新增可选的 ELECTRA 字级门控推理模块（ChineseErrorCorrector/llm/infer/electra_char_gate_infer.py）：在调用现有大模型纠错前，用轻量 TokenClassification 判断句子是否可能需要纠错，并支持 batch 推理；输入与 ErrorCorrect 一致（list[str]），便于仅对 need_correct 的句子调用 hf_infer / vllm_infer，从而降低延迟与算力消耗。未改动默认纠错模型路径与现有推理代码；依赖仍为 torch、transformers（需 Fast tokenizer）。说明见 contrib/ELECTRA_CHAR_GATE.md，权重托管于 Hugging Face，由常量 CHAR_GATE_HF_REPO_ID / 环境变量指定。