### PR TITLE
deps: bump nltk to 3.10.0 to resolve reported advisories

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -101,7 +101,7 @@ multiprocess==0.70.16
 nest-asyncio==1.6.0
 networkx==3.2.1
 ninja==1.11.1.4
-nltk==3.9.1
+nltk==3.10.0
 numba==0.61.2
 numpy==1.26.4
 nvidia-cublas-cu12==12.4.5.8


### PR DESCRIPTION
Updates `nltk` from 3.9.1 to 3.10.0.

Evidence:
- `requirements.txt` referenced `nltk==3.9.1`
- `osv-scanner` reported 16 nltk advisories before the update, including PYSEC-2026-96 / GHSA-7p94-766c-hgjp (CVSS 10.0, zip slip), PYSEC-2026-3582/3583/3584, PYSEC-2026-3581, PYSEC-2026-2235/2236/2237, PYSEC-2026-597, PYSEC-2026-2078, PYSEC-2026-98/97/99
- updated version: `3.10.0`

Validation:
- `osv-scanner` reports 0 findings for nltk after the update
- `pip install nltk==3.10.0` succeeds and `nltk.tokenize` imports cleanly

Scope: dependency update only, one line in `requirements.txt`.
